### PR TITLE
feat(auth): move refresh token persistence logic to backend

### DIFF
--- a/client/src/core/auth/PersistAuth.tsx
+++ b/client/src/core/auth/PersistAuth.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
-import { useAuth, useRefreshToken, useTogglePersistAuth } from "./hooks";
+import { useAuth, useRefreshToken } from "./hooks";
 import { Outlet } from "react-router-dom";
 
 export function PersistAuth() {
   const { auth } = useAuth();
-  const [persist] = useTogglePersistAuth();
   const refresh = useRefreshToken();
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -25,5 +24,5 @@ export function PersistAuth() {
     };
   }, [auth]);
 
-  return !persist ? <Outlet /> : isLoading ? <p>Loading...</p> : <Outlet />;
+  return isLoading ? <p>Loading...</p> : <Outlet />;
 }

--- a/client/src/core/auth/RequireAuth.tsx
+++ b/client/src/core/auth/RequireAuth.tsx
@@ -29,6 +29,7 @@ export function RequireAuth({ allowedRoles }: RequireAuthProps) {
 
   const isAuthorized = isAuthenticated && hasRequiredRoles;
 
+  //  todo: add notification for invalid/expired session.
   return isAuthorized ? (
     <Outlet />
   ) : isAuthenticated ? (

--- a/client/src/core/auth/hooks/useRefreshToken.ts
+++ b/client/src/core/auth/hooks/useRefreshToken.ts
@@ -24,6 +24,7 @@ export function useRefreshToken() {
         tokenPayload,
       };
       setAuth(authSession);
+      return accessToken;
     }
   };
 

--- a/client/src/core/auth/hooks/useRefreshToken.ts
+++ b/client/src/core/auth/hooks/useRefreshToken.ts
@@ -1,32 +1,42 @@
+import { useNavigate } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 import { AuthConstants, AuthTypes, AuthUtils } from "..";
 import { useAuth } from "./useAuth";
+
+let refreshPromise: Promise<string | null> | null = null;
 
 // todo: add handling for invalid access token
 export function useRefreshToken() {
   const { setAuth } = useAuth();
 
+  const navigate = useNavigate();
   const refresh = async () => {
-    const { PATH, REFRESH } = AuthConstants.AUTH_ENDPOINTS;
-    const endpoint = PATH + REFRESH;
+    if (!refreshPromise) {
+      refreshPromise = (async () => {
+        const { PATH, REFRESH } = AuthConstants.AUTH_ENDPOINTS;
+        const endpoint = PATH + REFRESH;
 
-    const accessToken: string | null = await AuthUtils.securedAxios
-      .post(endpoint, null, {
-        withCredentials: true,
-      })
-      .then((response) => response.data.accessToken)
-      .catch(() => null);
+        try {
+          const response = await AuthUtils.securedAxios.post(endpoint);
+          const accessToken = response.data.accessToken;
 
-    if (accessToken) {
-      const tokenPayload: AuthTypes.TokenPayload = jwtDecode(accessToken);
-      const authSession = {
-        accessToken,
-        tokenPayload,
-      };
-      setAuth(authSession);
-    } else setAuth(null);
+          const tokenPayload: AuthTypes.TokenPayload = jwtDecode(accessToken);
+          const authSession = {
+            accessToken,
+            tokenPayload,
+          };
 
-    return accessToken;
+          setAuth(authSession);
+          return accessToken;
+        } catch {
+          return null;
+        } finally {
+          refreshPromise = null;
+        }
+      })();
+    }
+
+    return refreshPromise;
   };
 
   return refresh;

--- a/client/src/core/auth/hooks/useRefreshToken.ts
+++ b/client/src/core/auth/hooks/useRefreshToken.ts
@@ -24,8 +24,9 @@ export function useRefreshToken() {
         tokenPayload,
       };
       setAuth(authSession);
-      return accessToken;
-    }
+    } else setAuth(null);
+
+    return accessToken;
   };
 
   return refresh;

--- a/client/src/core/auth/hooks/useRefreshToken.ts
+++ b/client/src/core/auth/hooks/useRefreshToken.ts
@@ -29,6 +29,7 @@ export function useRefreshToken() {
           setAuth(authSession);
           return accessToken;
         } catch {
+          setAuth(null);
           return null;
         } finally {
           refreshPromise = null;

--- a/client/src/core/auth/hooks/useSecuredAxios.ts
+++ b/client/src/core/auth/hooks/useSecuredAxios.ts
@@ -17,6 +17,8 @@ export function useSecuredAxios(): AxiosInstance {
   const { auth } = useAuth();
 
   useEffect(() => {
+    if (!auth?.accessToken) return;
+
     const requestIntercept = securedAxios.interceptors.request.use(
       (config) => {
         // means the request not a retry, it's the first attempt.

--- a/client/src/core/auth/hooks/useSecuredAxios.ts
+++ b/client/src/core/auth/hooks/useSecuredAxios.ts
@@ -43,6 +43,7 @@ export function useSecuredAxios(): AxiosInstance {
           // if a retry wasn't attempted yet, retry.
           prevRequest.sent = true;
           const newAccessToken = await refresh();
+          if (!newAccessToken) return Promise.reject(err); //  token refresh failed
           prevRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
           return securedAxios(prevRequest);
         }

--- a/server/src/data/constants/auth.constants.ts
+++ b/server/src/data/constants/auth.constants.ts
@@ -32,6 +32,7 @@ type CookieConfig = {
   cookieName: string;
   clearCookie: CookieOptions;
   persistentCookie: CookieOptions;
+  sessionCookie: CookieOptions;
 };
 type TokenConfig = {
   secret: string | undefined;
@@ -69,6 +70,11 @@ export const TOKEN_CONFIG_RECORD: TokenConfigRecord = {
         sameSite: "none",
         secure: true,
         maxAge: 24 * 60 * 60 * 1000, // 1 day
+      },
+      sessionCookie: {
+        httpOnly: true,
+        sameSite: "none",
+        secure: true,
       },
     },
   },

--- a/server/src/data/constants/auth.constants.ts
+++ b/server/src/data/constants/auth.constants.ts
@@ -30,8 +30,8 @@ export const ROLES_MAP: RolesMap = {
 export type TokenType = "access" | "refresh";
 type CookieConfig = {
   cookieName: string;
-  clearOptions: CookieOptions;
-  cookieOptions: CookieOptions;
+  clearCookie: CookieOptions;
+  persistentCookie: CookieOptions;
 };
 type TokenConfig = {
   secret: string | undefined;
@@ -59,12 +59,12 @@ export const TOKEN_CONFIG_RECORD: TokenConfigRecord = {
     } as jwt.SignOptions,
     cookieConfig: {
       cookieName: "refresh_token",
-      clearOptions: {
+      clearCookie: {
         httpOnly: true,
         sameSite: "none",
         secure: true, // *change to true in production/when not using thunderclient
       },
-      cookieOptions: {
+      persistentCookie: {
         httpOnly: true,
         sameSite: "none",
         secure: true,

--- a/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
+++ b/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
@@ -4,9 +4,6 @@ import { LoginOptions } from "../../schemas";
 import { createTokens, updateUserRefreshToken } from "../../utils";
 import { getVerifiedUser } from "./get-verified-user";
 
-const { refresh } = AUTH.TOKEN_CONFIG_RECORD;
-const { cookieConfig: refreshCookie } = refresh;
-
 /**
  * @public
  * @async
@@ -37,11 +34,20 @@ export async function handleLogin(
 
   if (!updatedUserId) return;
 
+  const { refresh } = AUTH.TOKEN_CONFIG_RECORD;
+  const { cookieConfig: refreshCookie } = refresh;
+
+  if (!refreshCookie)
+    throw new Error("Refresh token cookie configuration not set.");
+
+  const { cookieName, persistentCookie, sessionCookie } = refreshCookie;
+  const { isPersist } = req.body;
+
   //  cookie creation
   res.cookie(
-    refreshCookie!.cookieName, //  cookie name (could be anything really)
+    cookieName, //  cookie name (could be anything really)
     refreshToken,
-    refreshCookie!.persistentCookie
+    isPersist ? persistentCookie : sessionCookie
   );
   res.json({ accessToken });
 

--- a/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
+++ b/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
@@ -25,7 +25,11 @@ export async function handleLogin(
   if (!verifiedUser) return;
 
   const { isPersistentAuth } = req.body;
-  const { accessToken, refreshToken } = await createTokens(req, verifiedUser);
+  const { accessToken, refreshToken } = await createTokens(
+    req,
+    verifiedUser,
+    isPersistentAuth
+  );
 
   const updatedUserId = await updateUserRefreshToken(
     req,

--- a/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
+++ b/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
@@ -24,6 +24,7 @@ export async function handleLogin(
   const verifiedUser = await getVerifiedUser(req);
   if (!verifiedUser) return;
 
+  const { isPersistentAuth } = req.body;
   const { accessToken, refreshToken } = await createTokens(req, verifiedUser);
 
   const updatedUserId = await updateUserRefreshToken(
@@ -41,13 +42,12 @@ export async function handleLogin(
     throw new Error("Refresh token cookie configuration not set.");
 
   const { cookieName, persistentCookie, sessionCookie } = refreshCookie;
-  const { isPersist } = req.body;
 
   //  cookie creation
   res.cookie(
     cookieName, //  cookie name (could be anything really)
     refreshToken,
-    isPersist ? persistentCookie : sessionCookie
+    isPersistentAuth ? persistentCookie : sessionCookie
   );
   res.json({ accessToken });
 

--- a/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
+++ b/server/src/features/auth/controllers/handle-login/handle-login.controller.ts
@@ -41,7 +41,7 @@ export async function handleLogin(
   res.cookie(
     refreshCookie!.cookieName, //  cookie name (could be anything really)
     refreshToken,
-    refreshCookie!.cookieOptions
+    refreshCookie!.persistentCookie
   );
   res.json({ accessToken });
 

--- a/server/src/features/auth/controllers/handle-logout/handle-logout.controller.ts
+++ b/server/src/features/auth/controllers/handle-logout/handle-logout.controller.ts
@@ -36,6 +36,6 @@ export async function handleLogout(req: Request, res: Response) {
     await userDataService.updateRefreshToken(foundUser.userId, null);
   }
 
-  res.clearCookie(refreshCookie!.cookieName, refreshCookie!.clearOptions);
+  res.clearCookie(refreshCookie!.cookieName, refreshCookie!.clearCookie);
   return requestLogger.logStatus(204, "Logged out successfully.");
 }

--- a/server/src/features/auth/controllers/handle-refresh-token/handle-refresh-token.controller.ts
+++ b/server/src/features/auth/controllers/handle-refresh-token/handle-refresh-token.controller.ts
@@ -57,7 +57,7 @@ export async function handleRefreshToken(req: Request, res: Response) {
     res.cookie(
       refreshCookie!.cookieName, //  cookie name (could be anything really)
       newRefreshToken,
-      refreshCookie!.cookieOptions
+      refreshCookie!.persistentCookie
     );
     res.json({ accessToken });
   } catch (err) {

--- a/server/src/features/auth/controllers/handle-refresh-token/handle-refresh-token.controller.ts
+++ b/server/src/features/auth/controllers/handle-refresh-token/handle-refresh-token.controller.ts
@@ -40,7 +40,8 @@ export async function handleRefreshToken(req: Request, res: Response) {
 
     const { accessToken, refreshToken: newRefreshToken } = await createTokens(
       req,
-      foundUser
+      foundUser,
+      payload.isPersistentAuth
     );
 
     const updatedUserId = await updateUserRefreshToken(
@@ -54,10 +55,15 @@ export async function handleRefreshToken(req: Request, res: Response) {
     const { refresh } = AUTH.TOKEN_CONFIG_RECORD;
     const { cookieConfig: refreshCookie } = refresh;
 
+    if (!refreshCookie)
+      throw new Error("Refresh token cookie configuration not set.");
+
+    const { cookieName, persistentCookie, sessionCookie } = refreshCookie;
+
     res.cookie(
-      refreshCookie!.cookieName, //  cookie name (could be anything really)
+      cookieName, //  cookie name (could be anything really)
       newRefreshToken,
-      refreshCookie!.persistentCookie
+      payload.isPersistentAuth ? persistentCookie : sessionCookie
     );
     res.json({ accessToken });
   } catch (err) {

--- a/server/src/features/auth/schemas/login.schema.ts
+++ b/server/src/features/auth/schemas/login.schema.ts
@@ -15,7 +15,7 @@ export const loginOptions = z.object({
     },
   }),
 
-  isPersist: z.boolean().optional(),
+  isPersistentAuth: z.boolean().optional(),
 });
 
 export type LoginOptions = z.infer<typeof loginOptions>;

--- a/server/src/features/auth/schemas/login.schema.ts
+++ b/server/src/features/auth/schemas/login.schema.ts
@@ -14,6 +14,8 @@ export const loginOptions = z.object({
       if (!iss.input) return "Password is required.";
     },
   }),
+
+  isPersist: z.boolean().optional(),
 });
 
 export type LoginOptions = z.infer<typeof loginOptions>;

--- a/server/src/features/auth/schemas/refresh-token-payload.schema.ts
+++ b/server/src/features/auth/schemas/refresh-token-payload.schema.ts
@@ -4,5 +4,5 @@ export type RefreshTokenPayload = z.infer<typeof refreshTokenPayload>;
 
 export const refreshTokenPayload = z.object({
   userId: z.number(),
-  isPersist: z.boolean().optional(),
+  isPersistentAuth: z.boolean().optional(),
 });

--- a/server/src/features/auth/schemas/refresh-token-payload.schema.ts
+++ b/server/src/features/auth/schemas/refresh-token-payload.schema.ts
@@ -4,4 +4,5 @@ export type RefreshTokenPayload = z.infer<typeof refreshTokenPayload>;
 
 export const refreshTokenPayload = z.object({
   userId: z.number(),
+  isPersist: z.boolean().optional(),
 });

--- a/server/src/features/auth/utils/create-payload.util.ts
+++ b/server/src/features/auth/utils/create-payload.util.ts
@@ -10,7 +10,7 @@ type AccessTokenRequirements = {
 type RefreshTokenRequirements = {
   tokenType: Extract<AUTH.TokenType, "refresh">;
   userId: number;
-  isPersist?: boolean;
+  isPersistentAuth?: boolean;
 };
 
 type PayloadRequirements = AccessTokenRequirements | RefreshTokenRequirements;
@@ -88,10 +88,10 @@ function createAccessTokenPayload(
 function createRefreshTokenPayload(
   payloadRequirements: RefreshTokenRequirements
 ) {
-  const { userId, isPersist } = payloadRequirements;
+  const { userId, isPersistentAuth } = payloadRequirements;
   const payload: RefreshTokenPayload = {
     userId,
-    isPersist,
+    isPersistentAuth,
   };
 
   return payload;

--- a/server/src/features/auth/utils/create-payload.util.ts
+++ b/server/src/features/auth/utils/create-payload.util.ts
@@ -10,6 +10,7 @@ type AccessTokenRequirements = {
 type RefreshTokenRequirements = {
   tokenType: Extract<AUTH.TokenType, "refresh">;
   userId: number;
+  isPersist?: boolean;
 };
 
 type PayloadRequirements = AccessTokenRequirements | RefreshTokenRequirements;
@@ -87,9 +88,10 @@ function createAccessTokenPayload(
 function createRefreshTokenPayload(
   payloadRequirements: RefreshTokenRequirements
 ) {
-  const { userId } = payloadRequirements;
+  const { userId, isPersist } = payloadRequirements;
   const payload: RefreshTokenPayload = {
     userId,
+    isPersist,
   };
 
   return payload;

--- a/server/src/features/auth/utils/create-tokens.util.ts
+++ b/server/src/features/auth/utils/create-tokens.util.ts
@@ -47,7 +47,7 @@ export async function createTokens(
   const refreshTokenPayload: RefreshTokenPayload = createPayload({
     tokenType: "refresh",
     userId: verifiedUser.userId,
-    isPersist: isPersistentAuth,
+    isPersistentAuth,
   });
 
   const accessToken = createJwt({

--- a/server/src/features/auth/utils/create-tokens.util.ts
+++ b/server/src/features/auth/utils/create-tokens.util.ts
@@ -21,12 +21,15 @@ type Tokens = {
  * @param req
  * @param verifiedUser A {@link UserViewModel} used for retrieving the `User`'s `role`s and
  * creating the token `payload`.
+ * @param isPersistentAuth An optional boolean representing the persistence of the authentication state.
+ * `true` if the auth is persistent. `false` otherwise.
  * @returns A `Promise` that resolves to a {@link Tokens} object containing the `accessToken`
  * and `refreshToken`.
  */
 export async function createTokens(
   req: Request,
-  verifiedUser: UserViewModel
+  verifiedUser: UserViewModel,
+  isPersistentAuth?: boolean
 ): Promise<Tokens> {
   const { requestLogContext: requestLogger } = req;
 
@@ -44,6 +47,7 @@ export async function createTokens(
   const refreshTokenPayload: RefreshTokenPayload = createPayload({
     tokenType: "refresh",
     userId: verifiedUser.userId,
+    isPersist: isPersistentAuth,
   });
 
   const accessToken = createJwt({


### PR DESCRIPTION
Refresh tokens now include isPersist in their payload.

Backend sets either a session or persistent cookie based on this flag.

Removed persist flag and related logic from frontend (e.g., useTogglePersistAuth).

Updated handleLogin, handleRefreshToken, and createTokens to support persistence.

Renamed cookie config keys for clarity (clearOptions → clearCookie, etc.).

This simplifies frontend logic and allows different persistence settings per device.