### PR TITLE
feat!(projects): extract tag-related CRUD logic into separate repository classes

### DIFF
--- a/server/src/features/projects/services/repositories/application-industry.repository.ts
+++ b/server/src/features/projects/services/repositories/application-industry.repository.ts
@@ -1,0 +1,30 @@
+import { DbContext } from "@/db/csods";
+import { ApplicationIndustry } from "@/models";
+import { Repository } from "@/services";
+import {
+  ApplicationIndustryTable,
+  ApplicationIndustryViewModel,
+} from "../../types";
+
+export class ApplicationIndustryRepository extends Repository<ApplicationIndustryTable> {
+  public constructor(dbContext: DbContext) {
+    super(dbContext, ApplicationIndustry);
+  }
+
+  /**
+   * @public
+   * @async
+   * @function getAll
+   * @description Asynchronously retrieves up to 100 rows from the
+   * `application_industries` table in the database sorted by the
+   * `industry_id` column.
+   * @returns A `Promise` that resolves to the list of rows or
+   * `null` if the read operation fails.
+   */
+  public async getAll(): Promise<ApplicationIndustryViewModel[] | null> {
+    const applicationIndustries = await this.GetRows({
+      column: ApplicationIndustry.industryId,
+    });
+    return applicationIndustries;
+  }
+}

--- a/server/src/features/projects/services/repositories/database-technology.repository.ts
+++ b/server/src/features/projects/services/repositories/database-technology.repository.ts
@@ -1,0 +1,30 @@
+import { DbContext } from "@/db/csods";
+import { DatabaseTechnology } from "@/models";
+import { Repository } from "@/services";
+import {
+  DatabaseTechnologyTable,
+  DatabaseTechnologyViewModel,
+} from "../../types";
+
+export class DatabaseTechnologyRepository extends Repository<DatabaseTechnologyTable> {
+  public constructor(dbContext: DbContext) {
+    super(dbContext, DatabaseTechnology);
+  }
+
+  /**
+   * @public
+   * @async
+   * @function getAll
+   * @description Asynchronously retrieves up to 100 rows from the
+   * `database_technologies` table in the database sorted by the
+   * `database_id` column.
+   * @returns A `Promise` that resolves to the list of rows or
+   * `null` if the read operation fails.
+   */
+  public async getAll(): Promise<DatabaseTechnologyViewModel[] | null> {
+    const databaseTechnologies = await this.GetRows({
+      column: DatabaseTechnology.databaseId,
+    });
+    return databaseTechnologies;
+  }
+}

--- a/server/src/features/projects/services/repositories/dev-type.repository.ts
+++ b/server/src/features/projects/services/repositories/dev-type.repository.ts
@@ -1,0 +1,25 @@
+import { DbContext } from "@/db/csods";
+import { DevType } from "@/models";
+import { Repository } from "@/services";
+import { DevTypeTable, DevTypeViewModel } from "../../types";
+
+export class DevTypeRepository extends Repository<DevTypeTable> {
+  public constructor(dbContext: DbContext) {
+    super(dbContext, DevType);
+  }
+
+  /**
+   * @public
+   * @async
+   * @function getAll
+   * @description Asynchronously retrieves up to 100 rows from the
+   * `dev_types` table in the database sorted by the `dev_type_id`
+   * column.
+   * @returns A `Promise` that resolves to the list of rows or `null`
+   * if the read operation fails.
+   */
+  public async getAll(): Promise<DevTypeViewModel[] | null> {
+    const devTypes = await this.GetRows({ column: DevType.devTypeId });
+    return devTypes;
+  }
+}

--- a/server/src/features/projects/services/repositories/framework.repository.ts
+++ b/server/src/features/projects/services/repositories/framework.repository.ts
@@ -1,0 +1,25 @@
+import { DbContext } from "@/db/csods";
+import { Framework } from "@/models";
+import { Repository } from "@/services";
+import { FrameworkTable, FrameworkViewModel } from "../../types";
+
+export class FrameworkRepository extends Repository<FrameworkTable> {
+  public constructor(dbContext: DbContext) {
+    super(dbContext, Framework);
+  }
+
+  /**
+   * @public
+   * @async
+   * @function getAll
+   * @description Asynchronously retrieves up to 100 rows from the
+   * `frameworks` table in the database sorted by the
+   * `framework_id` column.
+   * @returns A `Promise` that resolves to the list of rows or
+   * `null` if the read operation fails.
+   */
+  public async getAll(): Promise<FrameworkViewModel[] | null> {
+    const frameworks = await this.GetRows({ column: Framework.frameworkId });
+    return frameworks;
+  }
+}

--- a/server/src/features/projects/services/repositories/index.ts
+++ b/server/src/features/projects/services/repositories/index.ts
@@ -1,2 +1,7 @@
+export * from "./application-industry.repository";
+export * from "./database-technology.repository";
+export * from "./dev-type.repository";
+export * from "./framework.repository";
+export * from "./programming-language.repository";
 export * from "./project-framework.repository";
 export * from "./project.repository";

--- a/server/src/features/projects/services/repositories/programming-language.repository.ts
+++ b/server/src/features/projects/services/repositories/programming-language.repository.ts
@@ -1,0 +1,30 @@
+import { DbContext } from "@/db/csods";
+import { ProgrammingLanguage } from "@/models";
+import { Repository } from "@/services";
+import {
+  ProgrammingLanguageTable,
+  ProgrammingLanguageViewModel,
+} from "../../types";
+
+export class ProgrammingLanguageRepository extends Repository<ProgrammingLanguageTable> {
+  public constructor(dbContext: DbContext) {
+    super(dbContext, ProgrammingLanguage);
+  }
+
+  /**
+   * @public
+   * @async
+   * @function getAll
+   * @description Asynchronously retrieves up to 100 rows from the
+   * `programming_languages` table in the database sorted by the
+   * `language_id` column.
+   * @returns A `Promise` that resolves to the list of rows or
+   * `null` if the read operation fails.
+   */
+  public async getAll(): Promise<ProgrammingLanguageViewModel[] | null> {
+    const programmingLanguages = await this.GetRows({
+      column: ProgrammingLanguage.languageId,
+    });
+    return programmingLanguages;
+  }
+}


### PR DESCRIPTION
- add `ApplicationIndustryRepository`
- add `DatabaseTechnologyRepository`
- add `DevTypeRepository`
- add `FrameworkRepository`
- add `ProgrammingLanguageRepository`
- These repositories handle database operations for the project's tag data, improving modularity and separation of concerns in the repo layer.